### PR TITLE
feat(layout): add initial layout plan

### DIFF
--- a/zine/layout.md
+++ b/zine/layout.md
@@ -1,0 +1,3 @@
+
+This file contains the layout plan for the zine: cover, table of contents, article, and footer.
+Planned sections: cover, toc, feature article, sidebar, footer.


### PR DESCRIPTION
Adds zine/layout.md describing cover, table of contents, article, and footer sections.
Fixes #1
